### PR TITLE
Prevent open-redirect vulnerabilities in the login flow

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,3 +21,4 @@ Contributors
 
 - `Gene Wood <http://github.com/gene1wood/>`_
 - `Terry <https://github.com/tpeng>`_
+- `Tim Pierce <https://github.com/qwrrty/>` (Adobe Systems)

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -20,6 +20,7 @@ from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.template import TemplateDoesNotExist
 from django.http import HttpResponseRedirect
+from django.utils.http import is_safe_url
 
 try:
     import urllib2 as _urllib
@@ -182,6 +183,10 @@ def signin(r):
             next_url = _urlparse.parse_qs(_urlparse.urlparse(unquote(next_url)).query)['next'][0]
     except:
         next_url = r.GET.get('next', get_reverse('admin:index'))
+
+    # Only permit signin requests where the next_url is a safe URL
+    if not is_safe_url(next_url):
+        return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
     r.session['login_next_url'] = next_url
 


### PR DESCRIPTION
Before submitting a SAML2 authentication request, check that the next URL in the login flow is safe to return to (as defined by Django's `is_safe_url` method).

This PR closes issue #16.