### PR TITLE
Add optional ASSERTION_URL setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,7 @@ How to use?
                 'CREATE_USER': 'path.to.your.new.user.hook.method',
                 'BEFORE_LOGIN': 'path.to.your.login.hook.method',
             },
+            'ASSERTION_URL': 'https://mysite.com', # Custom URL to validate incoming SAML requests against
         }
 
 #. In your SAML2 SSO identity provider, set the Single-sign-on URL and Audience
@@ -173,6 +174,11 @@ record is created. This method should accept ONE parameter of user dict.
 This method will be called before the user is logged in and after user
 attributes are returned by the SAML2 identity provider. This method should accept ONE parameter of user dict.
 
+**ASSERTION_URL** A URL to validate incoming SAML responses against. By default,
+django-saml2-auth will validate the SAML response's Service Provider address
+against the actual HTTP request's host and scheme. If this value is set, it
+will validate against ASSERTION_URL instead - perfect for when django running 
+behind a reverse proxy.
 
 Customize
 =========

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -36,6 +36,8 @@ else:
 
 
 def get_current_domain(r):
+    if settings.SAML2_AUTH['ASSERTION_URL']:
+        return settings.SAML2_AUTH['ASSERTION_URL']
     return '{scheme}://{host}'.format(
         scheme='https' if r.is_secure() else 'http',
         host=r.get_host(),

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -36,7 +36,7 @@ else:
 
 
 def get_current_domain(r):
-    if settings.SAML2_AUTH['ASSERTION_URL']:
+    if 'ASSERTION_URL' in settings.SAML2_AUTH:
         return settings.SAML2_AUTH['ASSERTION_URL']
     return '{scheme}://{host}'.format(
         scheme='https' if r.is_secure() else 'http',


### PR DESCRIPTION
We pass the result of `get_current_domain` to pysaml2 to validate
the source of the incoming StatusResponse (the scheme+host of the
request).

This is not viable in a reverse proxy scenario, in particular when the
host, port, and/or scheme of the django server changes with churn.

As a solution, alter `get_current_domain` to just use a setting
variable, `ASSERTION_URL`, instead of the scheme and host of the
incoming SAML request. If the setting is not present, use the
current behavior.