### PR TITLE
Return entityid

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -83,6 +83,7 @@ def _get_saml_client(domain):
                 'want_response_signed': False,
             },
         },
+        'entityid': acs_url,
     }
 
     spConfig = Saml2Config()


### PR DESCRIPTION
Makes django_saml2_auth play nice with Duo's SAML implementation.

As described in @mrhatch's comment [here](https://github.com/fangli/django-saml2-auth/issues/21#issuecomment-303710505)