### PR TITLE
adding optional configuration for ADFS SAML compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,8 @@ How to use?
                 'BEFORE_LOGIN': 'path.to.your.login.hook.method',
             },
             'ASSERTION_URL': 'https://mysite.com', # Custom URL to validate incoming SAML requests against
+            'ENTITY_ID': 'https://mysite.com/saml2_auth/acs/', # Populates the Issuer element in authn request
+            'NAME_ID_FORMAT': FormatString, # Sets the Format property of authn NameIDPolicy element
         }
 
 #. In your SAML2 SSO identity provider, set the Single-sign-on URL and Audience
@@ -177,8 +179,13 @@ attributes are returned by the SAML2 identity provider. This method should accep
 **ASSERTION_URL** A URL to validate incoming SAML responses against. By default,
 django-saml2-auth will validate the SAML response's Service Provider address
 against the actual HTTP request's host and scheme. If this value is set, it
-will validate against ASSERTION_URL instead - perfect for when django running 
+will validate against ASSERTION_URL instead - perfect for when django running
 behind a reverse proxy.
+
+**ENTITY_ID** The optional entity ID string to be passed in the 'Issuer' element of authn request, if required by the IDP.
+
+**NAME_ID_FORMAT** Set to the string 'None', to exclude sending the 'Format' property of the 'NameIDPolicy' element in authn requests.
+Default value if not specified is 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'.
 
 Customize
 =========

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -89,6 +89,12 @@ def _get_saml_client(domain):
         },
     }
 
+    if 'ENTITY_ID' in settings.SAML2_AUTH:
+        saml_settings['entityid'] = settings.SAML2_AUTH['ENTITY_ID']
+
+    if 'NAME_ID_FORMAT' in settings.SAML2_AUTH:
+        saml_settings['service']['sp']['name_id_format'] = settings.SAML2_AUTH['NAME_ID_FORMAT']
+
     spConfig = Saml2Config()
     spConfig.load(saml_settings)
     spConfig.allow_unknown_attributes = True

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,6 @@ setup(
 
     packages=find_packages(),
 
-    install_requires=['pysaml2==4.0.5'],
+    install_requires=['pysaml2==4.5.0'],
     include_package_data=True,
 )


### PR DESCRIPTION
@fangli , would you consider merging this pull request?

This is related to the issue https://github.com/fangli/django-saml2-auth/issues/7

I bumped into a few issues getting a compatible integration with ADFS, and added a couple configuration options to allow accommodating ADFS's SAML2 interpretation.

The changes are to add optional settings to pass down to pysaml2 for allowing the addition of the pysaml2 `entityid` for authentication requests to populate the `Issuer` element, and a change to allow setting (or for ADFS, excluding) the `Format` property on the `NameIDPolicy` element via the pysaml2 `name_id_format`.

Also, a change in the setup.py to bump the version of pysaml2 to 4.5.0 to support the option to pass the `name_id_format`.