### PR TITLE
Get the currently active user model instead

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -13,7 +13,8 @@ from saml2.config import Config as Saml2Config
 from django import get_version
 from pkg_resources import parse_version
 from django.conf import settings
-from django.contrib.auth.models import (User, Group)
+from django.contrib.auth.models import Group
+from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import login, logout
 from django.shortcuts import render
@@ -28,6 +29,8 @@ except:
     import urllib.request as _urllib
     import urllib.error
     import urllib.parse
+
+User = get_user_model()
 
 if parse_version(get_version()) >= parse_version('1.7'):
     from django.utils.module_loading import import_string


### PR DESCRIPTION
- Instead of importing the User model directly, use the `get_user_model`
function.