### PR TITLE
Add JWT Token Support for Single Page Applications through Django Rest Framework

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,3 +27,4 @@ Contributors
 - `Tonymke <https://github.com/tonymke/>`_
 - `pintor <https://github.com/pintor>`_
 - `BaconAndEggs <https://github.com/BaconAndEggs>`_
+- `Ryan Mahaffey <https://github.com/mahaffey>`_

--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,8 @@ How to use?
             'ASSERTION_URL': 'https://mysite.com', # Custom URL to validate incoming SAML requests against
             'ENTITY_ID': 'https://mysite.com/saml2_auth/acs/', # Populates the Issuer element in authn request
             'NAME_ID_FORMAT': FormatString, # Sets the Format property of authn NameIDPolicy element
+            'USE_JWT': False, # Set this to True if you are running a Single Page Application (SPA) with Django Rest Framework (DRF), and are using JWT authentication to authorize client users
+            'FRONTEND_URL': 'https://myfrontendclient.com', # Redirect URL for the client if you are using JWT auth with DRF. See explanation below
         }
 
 #. In your SAML2 SSO identity provider, set the Single-sign-on URL and Audience
@@ -186,6 +188,12 @@ behind a reverse proxy.
 
 **NAME_ID_FORMAT** Set to the string 'None', to exclude sending the 'Format' property of the 'NameIDPolicy' element in authn requests.
 Default value if not specified is 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'.
+
+**USE_JWT** Set this to the boolean True if you are using Django Rest Framework with JWT authentication
+
+**FRONTEND_URL** If USE_JWT is True, you should set the URL of where your frontend is located (will default to DEFAULT_NEXT_URL if you fail to do so). Once the client is authenticated through the SAML/SSO, your client is redirected to the FRONTEND_URL with the user id (uid) and JWT token (token) as query parameters.
+Example: 'https://myfrontendclient.com/?uid=<user id>&token=<jwt token>'
+With these params your client can now authenticate will server resources.
 
 Customize
 =========

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -13,14 +13,18 @@ from saml2.config import Config as Saml2Config
 from django import get_version
 from pkg_resources import parse_version
 from django.conf import settings
-from django.contrib.auth.models import (User, Group)
+from django.contrib.auth.models import Group
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth import login, logout
+from django.contrib.auth import login, logout, get_user_model
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.template import TemplateDoesNotExist
 from django.http import HttpResponseRedirect
 from django.utils.http import is_safe_url
+
+
+# default User or custom User. Now both will work.
+User = get_user_model()
 
 try:
     import urllib2 as _urllib

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -180,7 +180,7 @@ def acs(r):
     else:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
-    if settings.SAML2_AUTH.get('USE_JWT'):
+    if settings.SAML2_AUTH.get('USE_JWT') is True:
         # We use JWT auth send token to frontend
         jwt_token = jwt_encode(target_user)
         query = '?uid={}&token={}'.format(target_user.id, jwt_token)

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -180,7 +180,7 @@ def acs(r):
     else:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
-    if settings.SAML2_AUTH['USE_JWT']:
+    if settings.SAML2_AUTH.get('USE_JWT'):
         # We use JWT auth send token to frontend
         jwt_token = jwt_encode(target_user)
         query = '?uid={}&token={}'.format(target_user.id, jwt_token)

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
 
     packages=find_packages(),
 
-    install_requires=['pysaml2>=4.5.0'],
+    install_requires=['pysaml2>=4.5.0',
+                      'djangorestframework-jwt'],
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     packages=find_packages(),
 
     install_requires=['pysaml2>=4.5.0',
-                      'djangorestframework-jwt'],
+                      'djangorestframework-jwt',
+                      'django-rest-auth', ],
     include_package_data=True,
 )


### PR DESCRIPTION
"Closes" Issue #56 

I also added the previously asked for get_user_model definition of a User in views.py.

Updated README to reflect new possible settings that I created.

Added two dependencies to this module in setup.py (djangorestframwork-jwt and django-rest-auth).

- Is there a way to have conditional dependencies to keep this more lightweight for the users who do not have a need for DRF?



My implementation adds a few lines of code before the normal login sequence in views.py.

Instead of immediate redirection to the defined DEFAULT_NEXT_URL, it first checks to see if the user has enabled USE_JWT. If this is set to True, my block of code is then executed. 

1. We first create the JWT from the target_user using jwt_encode
2. We then check to see if the user has implemented the FRONTEND_URL, if not we fall back to the default, which is DEFAULT_NEXT_URL
3. We now create the query string consisting of the user id (uid) and JWT (token).

- Example URL: https://myfrontend.com/?uid=(user_id)&token=(jwt token)

4. We then redirect to the frontend_url with the query params appended to the string
5. The client user can now use this token and uid to send with every fetch request, thus enabling SSO/SAML for single page applications


Any feedback would be great! Thanks
