### PR TITLE
Reorganize code and use safer default configuration settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Virtual environment
+venv/
+
 # C extensions
 *.so
 
@@ -60,3 +63,9 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# Temp files
+*.swp
+
+# Misc.
+.DS_Store

--- a/README.rst
+++ b/README.rst
@@ -116,24 +116,29 @@ How to use?
 
 #. In settings.py, add the SAML2 related configuration.
 
-    Please note, the only required setting is **METADATA_AUTO_CONF_URL**.
+    Please note that **DEFAULT_NEXT_URL** is required, as is one of either
+    **METADATA_AUTO_CONF_URL** or **METADATA_LOCAL_FILE_PATH**.
     The following block shows all required and optional configuration settings
     and their default values.
 
     .. code-block:: python
 
         SAML2_AUTH = {
+            # REQUIRED SETTINGS
+
+            'DEFAULT_NEXT_URL': '[url]',  # Redirect user to this url after login.
+
             # Metadata is required, choose either remote url or local file path
             'METADATA_AUTO_CONF_URL': '[The auto(dynamic) metadata configuration URL of SAML2]',
             'METADATA_LOCAL_FILE_PATH': '[The metadata configuration file path]',
 
-            # Optional settings below
-            'DEFAULT_NEXT_URL': '/admin',  # Custom target redirect URL after the user get logged in. Default to /admin if not set. This setting will be overwritten if you have parameter ?next= specificed in the login URL.
-            'CREATE_USER': 'TRUE', # Create a new Django user when a new user logs in. Defaults to True.
+            # OPTIONAL SETTINGS
+
+            'CREATE_USER': False, # Create a new Django user when a new user logs in. Defaults to False.
             'NEW_USER_PROFILE': {
                 'USER_GROUPS': [],  # The default group name when a new user logs in
                 'ACTIVE_STATUS': True,  # The default active status for new users
-                'STAFF_STATUS': True,  # The staff status for new users
+                'STAFF_STATUS': False,  # The staff status for new users
                 'SUPERUSER_STATUS': False,  # The superuser status for new users
             },
             'ATTRIBUTES_MAP': {  # Change Email/UserName/FirstName/LastName to corresponding SAML2 userprofile attributes.
@@ -159,6 +164,8 @@ How to use?
 
 Explanation
 -----------
+
+**DEFAULT_NEXT_URL** Target redirect URL after the user logs in. This setting will be ignored if you have the query string parameter `?next=` specified in the login URL.
 
 **METADATA_AUTO_CONF_URL** Auto SAML2 metadata configuration URL
 

--- a/django_saml2_auth/conf.py
+++ b/django_saml2_auth/conf.py
@@ -1,0 +1,70 @@
+from django_saml2_auth.utils import get_reverse
+from saml2 import BINDING_HTTP_POST, BINDING_HTTP_REDIRECT
+from saml2.client import Saml2Client
+from saml2.config import Config as Saml2Config
+
+from django.conf import settings
+
+
+def get_saml_client(domain):
+    sp_config = get_saml_config(domain)
+    saml_client = Saml2Client(config=sp_config)
+    return saml_client
+
+
+def get_saml_config(domain):
+    settings = parse_settings(domain)
+    sp_config = Saml2Config()
+    sp_config.load(settings)
+    sp_config.allow_unknown_attributes = True
+    return sp_config
+
+
+def parse_settings(domain):
+    acs_url = domain + get_reverse(['acs', 'django_saml2_auth:acs'])
+    metadata = _get_metadata()
+
+    saml_settings = {
+        'metadata': metadata,
+        'service': {
+            'sp': {
+                'endpoints': {
+                    'assertion_consumer_service': [
+                        (acs_url, BINDING_HTTP_REDIRECT),
+                        (acs_url, BINDING_HTTP_POST)
+                    ],
+                },
+                'allow_unsolicited': True,
+                'authn_requests_signed': False,
+                'logout_requests_signed': True,
+                'want_assertions_signed': True,
+                'want_response_signed': False,
+            },
+        },
+    }
+
+    if 'ENTITY_ID' in settings.SAML2_AUTH:
+        saml_settings['entityid'] = settings.SAML2_AUTH['ENTITY_ID']
+
+    if 'NAME_ID_FORMAT' in settings.SAML2_AUTH:
+        saml_settings['service']['sp']['name_id_format'] = settings.SAML2_AUTH['NAME_ID_FORMAT']
+
+    return saml_settings
+
+
+def _get_metadata():
+    if 'METADATA_LOCAL_FILE_PATH' in settings.SAML2_AUTH:
+        return {
+            'local': [settings.SAML2_AUTH['METADATA_LOCAL_FILE_PATH']]
+        }
+    elif 'METADATA_AUTO_CONF_URL' in settings.SAML2_AUTH:
+        return {
+            'remote': [
+                {
+                    "url": settings.SAML2_AUTH['METADATA_AUTO_CONF_URL'],
+                },
+            ]
+        }
+    else:
+        raise Exception('Invalid configuration, one of "METADATA_LOCAL_FILE_PATH" '
+                        'or "METADATA_AUTO_CONF_URL" is required')

--- a/django_saml2_auth/utils.py
+++ b/django_saml2_auth/utils.py
@@ -1,0 +1,30 @@
+from pkg_resources import parse_version
+
+from django import get_version
+from django.conf import settings
+
+
+def get_reverse(objs):
+    # In order to support different django version, I have to do this
+    if parse_version(get_version()) >= parse_version('2.0'):
+        from django.urls import reverse, NoReverseMatch
+    else:
+        from django.core.urlresolvers import reverse, NoReverseMatch
+    if objs.__class__.__name__ not in ['list', 'tuple']:
+        objs = [objs]
+
+    for obj in objs:
+        try:
+            return reverse(obj)
+        except NoReverseMatch:
+            pass
+    raise Exception('We got a URL reverse issue: %s. This is a known issue but please still submit a ticket at https://github.com/fangli/django-saml2-auth/issues/new' % str(objs))
+
+
+def get_sp_domain(r):
+    if 'ASSERTION_URL' in settings.SAML2_AUTH:
+        return settings.SAML2_AUTH['ASSERTION_URL']
+    return '{scheme}://{host}'.format(
+        scheme='https' if r.is_secure() else 'http',
+        host=r.get_host(),
+    )


### PR DESCRIPTION
There are three primary changes in this PR:
1. Move helper functions into their own files. Mostly copy-and-paste, but note that `get_reverse()` now only catches `NoReverseMatch`, rather than having a bare `except`. `_get_metadata()` also now raises an exception if neither `METADATA_AUTO_CONF_PATH` or `METADATA_LOCAL_FILE_PATH` are set.
2. Don't include function views in the lists passed to `get_reverse()`. This gives users the opportunity to override the views in their own code.
3. Change a number of defaults for the configuration options. In particular:
    - `DEFAULT_NEXT_URL` is required, rather than defaulting to `admin:index`.
    - `CREATE_USER` is `False`.
    - `STAFF_STATUS` in `NEW_USER_PROFILE` is `False`.

The rationale behind 3 is that the current defaults are too permissive and probably don't make sense for most applications. If you're allowing users to log into your application using a third party identity provider, and a new user is created with the third party, it seems unlikely that most applications would want to immediately give that new user staff access and direct them to the admin panel. Staff access and admin panel redirection make sense if you're using an IdP to manage users in your own company/organization, but that probably isn't the norm. So I think it's acceptable to make the developer change a few additional defaults in order to auto-create users with unusual permissions.