### PR TITLE
Support `inline` pySAML2 option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,7 @@ How to use?
             # Metadata is required, choose either remote url or local file path
             'METADATA_AUTO_CONF_URL': '[The auto(dynamic) metadata configuration URL of SAML2]',
             'METADATA_LOCAL_FILE_PATH': '[The metadata configuration file path]',
+            'METADATA_XML_STRING': '[A stringified XML configuration]',
 
             # Optional settings below
             'DEFAULT_NEXT_URL': '/admin',  # Custom target redirect URL after the user get logged in. Default to /admin if not set. This setting will be overwritten if you have parameter ?next= specificed in the login URL.
@@ -163,6 +164,8 @@ Explanation
 **METADATA_AUTO_CONF_URL** Auto SAML2 metadata configuration URL
 
 **METADATA_LOCAL_FILE_PATH** SAML2 metadata configuration file path
+
+**METADATA_XML_STRING** SAML2 metadata configuration as a string (i.e. stringified XML)
 
 **CREATE_USER** Determines if a new Django user should be created for new users.
 

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -16,6 +16,7 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import login, logout, get_user_model
+from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.template import TemplateDoesNotExist
@@ -72,7 +73,7 @@ def _get_metadata():
         return {
             'local': [settings.SAML2_AUTH['METADATA_LOCAL_FILE_PATH']]
         }
-    else:
+    elif 'METADATA_AUTO_CONF_URL' in settings.SAML2_AUTH:
         return {
             'remote': [
                 {
@@ -80,6 +81,12 @@ def _get_metadata():
                 },
             ]
         }
+    elif 'METADATA_XML_STRING' in settings.SAML2_AUTH:
+        return {
+            'inline': [settings.SAML2_AUTH['METADATA_XML_STRING']]
+        }
+    else:
+        raise ImproperlyConfigured("SAML2 Auth requires a METADATA setting")
 
 
 def _get_saml_client(domain):


### PR DESCRIPTION
PySAML2 also supports the `inline` metadata format where a stringified XML is provided to the library.  This builds on #61 and simplifies cases like #27 by eliminating the need to write the config to a file (which is probably not safe in production).  In our case, we wanted to inject the config into a docker container using an ENV variable.