### PR TITLE
Fix `reverse` error

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -220,13 +220,19 @@ def signin(r):
     except:
         import urllib.parse as _urlparse
         from urllib.parse import unquote
-    next_url = r.GET.get('next', settings.SAML2_AUTH.get('DEFAULT_NEXT_URL', get_reverse('admin:index')))
+
+    # make sure reverse isn't called if DEFAULT_NEXT_URL is found
+    next_url_value = settings.SAML2_AUTH.get('DEFAULT_NEXT_URL')
+    if next_url_value is None:
+        next_url_value = get_reverse('admin:index')
+
+    next_url = r.GET.get('next', next_url_value)
 
     try:
         if 'next=' in unquote(next_url):
             next_url = _urlparse.parse_qs(_urlparse.urlparse(unquote(next_url)).query)['next'][0]
     except:
-        next_url = r.GET.get('next', settings.SAML2_AUTH.get('DEFAULT_NEXT_URL', get_reverse('admin:index')))
+        next_url = r.GET.get('next', next_url_value)
 
     # Only permit signin requests where the next_url is a safe URL
     if not is_safe_url(next_url, None):

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -123,7 +123,10 @@ def welcome(r):
     try:
         return render(r, 'django_saml2_auth/welcome.html', {'user': r.user})
     except TemplateDoesNotExist:
-        return HttpResponseRedirect(settings.SAML2_AUTH.get('DEFAULT_NEXT_URL', get_reverse('admin:index')))
+        url = settings.SAML2_AUTH.get('DEFAULT_NEXT_URL')
+        if url is None:
+            url = get_reverse('admin:index')
+        return HttpResponseRedirect(url)
 
 
 def denied(r):
@@ -150,7 +153,10 @@ def _create_new_user(username, email, firstname, lastname):
 def acs(r):
     saml_client = _get_saml_client(get_current_domain(r))
     resp = r.POST.get('SAMLResponse', None)
-    next_url = r.session.get('login_next_url', settings.SAML2_AUTH.get('DEFAULT_NEXT_URL', get_reverse('admin:index')))
+    next_url_value = settings.SAML2_AUTH.get('DEFAULT_NEXT_URL')
+    if next_url_value is None:
+        next_url_value = get_reverse('admin:index')
+    next_url = r.session.get('login_next_url', next_url_value)
 
     if not resp:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))


### PR DESCRIPTION
Because the `reverse` call is included as a parameter to a `get` call, the existing code attempts to `reverse` the admin site even if a `DEFAULT_NEXT_URL` is provided.  For users without an admin site, this causes errors.  This patch tweaks the logic so `reverse` is only run if `DEFAULT_NEXT_URL` is _**not**_ provided.