### PR TITLE
Added subject nameid setting.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,7 @@ How to use?
                 'first_name': 'FirstName',
                 'last_name': 'LastName',
             },
+            'SUBJECT_NAMEID_MAPPING': 'email', # Change email/username/first_name/last_name to map to SAMLSUBJECT NAMEID property. 
             'TRIGGER': {
                 'CREATE_USER': 'path.to.your.new.user.hook.method',
                 'BEFORE_LOGIN': 'path.to.your.login.hook.method',
@@ -169,6 +170,10 @@ Explanation
 **NEW_USER_PROFILE** Default settings for newly created users
 
 **ATTRIBUTES_MAP** Mapping of Django user attributes to SAML2 user attributes
+
+**SUBJECT_NAMEID_MAPPING** Mapping of Django user attribute to SAMLSUBJECT NAMEID
+property. This is used to map to the Django user if no Attribute Statements were 
+found in the SAML2 response. 
 
 **TRIGGER** Hooks to trigger additional actions during user login and creation
 flows. These TRIGGER hooks are strings containing a `dotted module name <https://docs.python.org/3/tutorial/modules.html#packages>`_

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -164,16 +164,22 @@ def acs(r):
     if user_identity is None:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
-    user_email = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('email', 'Email')][0]
-    user_name = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('username', 'UserName')][0]
-    user_first_name = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('first_name', 'FirstName')][0]
-    user_last_name = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('last_name', 'LastName')][0]
+    if not user_identity:
+        subject_name_id = settings.SAML2_AUTH.get('SUBJECT_NAMEID_MAPPING', 'email')
+        subject_text = authn_response.get_subject().text
+        user_query = { subject_name_id: subject_text }
+    else:
+        user_email = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('email', 'Email')][0]
+        user_name = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('username', 'UserName')][0]
+        user_first_name = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('first_name', 'FirstName')][0]
+        user_last_name = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('last_name', 'LastName')][0]
+        user_query = { 'username': user_name }
 
     target_user = None
     is_new_user = False
 
     try:
-        target_user = User.objects.get(username=user_name)
+        target_user = User.objects.get(** user_query)
         if settings.SAML2_AUTH.get('TRIGGER', {}).get('BEFORE_LOGIN', None):
             import_string(settings.SAML2_AUTH['TRIGGER']['BEFORE_LOGIN'])(user_identity)
     except User.DoesNotExist:


### PR DESCRIPTION
I'm not sure if this is a feature that others would need but I was forced to add this to my fork so I thought I'd share it just in case it could help others.

My IP does not send back attribute statements, only the subject nameid. So I added the ability to set a subject nameid, and then query Django Users for that field. This only happens in the case that attribute statements could not be found, and thus the `user_identity` is empty.