### PR TITLE
Reload user object after BEFORE_LOGIN/CREATE_USER hooks are run

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,7 @@ How to use?
             'TRIGGER': {
                 'CREATE_USER': 'path.to.your.new.user.hook.method',
                 'BEFORE_LOGIN': 'path.to.your.login.hook.method',
+                'AFTER_LOGIN': 'path.to.your.after.login.hook.method',
             },
             'ASSERTION_URL': 'https://mysite.com', # Custom URL to validate incoming SAML requests against
             'ENTITY_ID': 'https://mysite.com/saml2_auth/acs/', # Populates the Issuer element in authn request
@@ -183,6 +184,10 @@ record is created. This method should accept ONE parameter of user dict.
 **TRIGGER.BEFORE_LOGIN** A method to be called when an existing user logs in.
 This method will be called before the user is logged in and after user
 attributes are returned by the SAML2 identity provider. This method should accept ONE parameter of user dict.
+
+**TRIGGER.AFTER_LOGIN** A method to be called when an existing user logs in.
+This method will be called after the user is logged in and after user
+attributes are returned by the SAML2 identity provider. This method should accept TWO parameters of session and user dict.
 
 **ASSERTION_URL** A URL to validate incoming SAML responses against. By default,
 django-saml2-auth will validate the SAML response's Service Provider address

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -187,6 +187,7 @@ def acs(r):
             return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
     r.session.flush()
+    target_user = User.objects.get(username=user_name)
 
     if target_user.is_active:
         target_user.backend = 'django.contrib.auth.backends.ModelBackend'

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -192,6 +192,10 @@ def acs(r):
     if target_user.is_active:
         target_user.backend = 'django.contrib.auth.backends.ModelBackend'
         login(r, target_user)
+
+        if settings.SAML2_AUTH.get('TRIGGER', {}).get('AFTER_LOGIN', None):
+            import_string(settings.SAML2_AUTH['TRIGGER']['AFTER_LOGIN'])(r.session, user_identity)
+
     else:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 


### PR DESCRIPTION
If a user's `is_active` status is changed in the configured BEFORE_LOGIN or CREATE_USER functions, this change isn't seen when checking `is_active` to log the user in, so they can be incorrectly granted/denied access based on the stale value. This PR fixes this by reloading the user object before the check.