### PR TITLE
Catch NoReverseMatch instead of having a bare except

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -52,17 +52,17 @@ def get_current_domain(r):
 
 def get_reverse(objs):
     '''In order to support different django version, I have to do this '''
-    if parse_version(get_version()) >= parse_version('2.0'):
-        from django.urls import reverse
+    if parse_version(get_version()) >= parse_version('1.10'):
+        from django.urls import NoReverseMatch, reverse
     else:
-        from django.core.urlresolvers import reverse
+        from django.core.urlresolvers import NoReverseMatch, reverse
     if objs.__class__.__name__ not in ['list', 'tuple']:
         objs = [objs]
 
     for obj in objs:
         try:
             return reverse(obj)
-        except:
+        except NoReverseMatch:
             pass
     raise Exception('We got a URL reverse issue: %s. This is a known issue but please still submit a ticket at https://github.com/fangli/django-saml2-auth/issues/new' % str(objs))
 


### PR DESCRIPTION
A bare `except:` is generally bad practice because it can lead to unexpected behavior, such as handling `KeyboardInterrupt`. It is cleaner to be specific about what error conditions this code can handle: failed url lookups, i.e. `NoRevereMatch`.

Also, Django changed the location of these imports in 1.10. While it was still possible to use the old locations until 2.0, a warning would be logged. The warning is avoided by changing the version this code checks for.