### PR TITLE
Use SAML's subject if no username is set on ATTRIBUTES_MAP

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -165,7 +165,12 @@ def acs(r):
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
     user_email = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('email', 'Email')][0]
-    user_name = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('username', 'UserName')][0]
+    try:
+        user_name = user_identity[settings.SAML2_AUTH['ATTRIBUTES_MAP']['username']][0]
+    except KeyError:
+        # If username key is not defined, or is invalid,
+        # use the auth response username
+        user_name = authn_response.get_subject().text
     user_first_name = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('first_name', 'FirstName')][0]
     user_last_name = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('last_name', 'LastName')][0]
 
@@ -178,7 +183,7 @@ def acs(r):
             import_string(settings.SAML2_AUTH['TRIGGER']['BEFORE_LOGIN'])(user_identity)
     except User.DoesNotExist:
         new_user_should_be_created = settings.SAML2_AUTH.get('CREATE_USER', True)
-        if new_user_should_be_created: 
+        if new_user_should_be_created:
             target_user = _create_new_user(user_name, user_email, user_first_name, user_last_name)
             if settings.SAML2_AUTH.get('TRIGGER', {}).get('CREATE_USER', None):
                 import_string(settings.SAML2_AUTH['TRIGGER']['CREATE_USER'])(user_identity)


### PR DESCRIPTION
I'm not sure how other SAML SP works, but Okta does't have a default `UserName` attribute, but you are able to get the username from the subject.

With this change, if the `username` attribute is not explicitly set on ATTRIBUTES_MAP, it is possible to use the subject text as username.