### PR TITLE
Use get_by_natural_key() instead of get()

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -173,12 +173,12 @@ def acs(r):
     is_new_user = False
 
     try:
-        target_user = User.objects.get(username=user_name)
+        target_user = User.objects.get_by_natural_key(user_name)
         if settings.SAML2_AUTH.get('TRIGGER', {}).get('BEFORE_LOGIN', None):
             import_string(settings.SAML2_AUTH['TRIGGER']['BEFORE_LOGIN'])(user_identity)
     except User.DoesNotExist:
         new_user_should_be_created = settings.SAML2_AUTH.get('CREATE_USER', True)
-        if new_user_should_be_created: 
+        if new_user_should_be_created:
             target_user = _create_new_user(user_name, user_email, user_first_name, user_last_name)
             if settings.SAML2_AUTH.get('TRIGGER', {}).get('CREATE_USER', None):
                 import_string(settings.SAML2_AUTH['TRIGGER']['CREATE_USER'])(user_identity)

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -173,7 +173,10 @@ def acs(r):
     is_new_user = False
 
     try:
-        target_user = User.objects.get_by_natural_key(user_name)
+        if hasattr(User.objects, 'get_by_natural_key'):
+            target_user = User.objects.get_by_natural_key(user_name)
+        else:
+            target_user = User.objects.get(username=user_name)
         if settings.SAML2_AUTH.get('TRIGGER', {}).get('BEFORE_LOGIN', None):
             import_string(settings.SAML2_AUTH['TRIGGER']['BEFORE_LOGIN'])(user_identity)
     except User.DoesNotExist:


### PR DESCRIPTION
We use `email` instead of `username` as our natural key. The library should get the user using the value nominated by `User.USERNAME_FIELD`.