### PR TITLE
New config parameters

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,4 +29,5 @@ Contributors
 - `BaconAndEggs <https://github.com/BaconAndEggs>`_
 - `Ryan Mahaffey <https://github.com/mahaffey>`_
 - `ayr-ton <https://github.com/ayr-ton>`_
-_ `kevPo <https://github.com/kevPo>`_
+- `kevPo <https://github.com/kevPo>`_
+- `chriskj <https://github.com/chriskj>`_

--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,8 @@ How to use?
             'NAME_ID_FORMAT': FormatString, # Sets the Format property of authn NameIDPolicy element
             'USE_JWT': False, # Set this to True if you are running a Single Page Application (SPA) with Django Rest Framework (DRF), and are using JWT authentication to authorize client users
             'FRONTEND_URL': 'https://myfrontendclient.com', # Redirect URL for the client if you are using JWT auth with DRF. See explanation below
+            'WANT_ASSERTIONS_SIGNED': True, # Require each assertion to be signed
+            'WANT_RESPONSE_SIGNED': False, # Require response to be signed
         }
 
 #. In your SAML2 SSO identity provider, set the Single-sign-on URL and Audience
@@ -212,6 +214,10 @@ Default value if not specified is 'urn:oasis:names:tc:SAML:2.0:nameid-format:tra
 **FRONTEND_URL** If USE_JWT is True, you should set the URL of where your frontend is located (will default to DEFAULT_NEXT_URL if you fail to do so). Once the client is authenticated through the SAML/SSO, your client is redirected to the FRONTEND_URL with the user id (uid) and JWT token (token) as query parameters.
 Example: 'https://myfrontendclient.com/?uid=<user id>&token=<jwt token>'
 With these params your client can now authenticate will server resources.
+
+**WANT_ASSERTIONS_SIGNED** Set this to the boolean False if your provider doesn't sign each assertion.
+
+**WANT_RESPONSE_SIGNED** Set this to the boolean True if you require your provider to sign the response.
 
 Customize
 =========

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -221,8 +221,8 @@ def acs(r):
     if settings.SAML2_AUTH.get('USE_SIMPLE_JWT') is True:
         refresh = RefreshToken.for_user(target_user)
 
-        refresh['user_username'] = target_user.username
-        refresh['user_email'] = target_user.email
+        refresh['username'] = target_user.username
+        refresh['email'] = target_user.email
 
         # We use JWT auth send token to frontend
         access_token = str(refresh.access_token)

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -118,6 +118,12 @@ def _get_saml_client(domain):
     if 'NAME_ID_FORMAT' in settings.SAML2_AUTH:
         saml_settings['service']['sp']['name_id_format'] = settings.SAML2_AUTH['NAME_ID_FORMAT']
 
+    if 'WANT_ASSERTIONS_SIGNED' in settings.SAML2_AUTH:
+        saml_settings['service']['sp']['want_assertions_signed'] = settings.SAML2_AUTH['WANT_ASSERTIONS_SIGNED']
+
+    if 'WANT_RESPONSE_SIGNED' in settings.SAML2_AUTH:
+        saml_settings['service']['sp']['want_response_signed'] = settings.SAML2_AUTH['WANT_RESPONSE_SIGNED']
+
     spConfig = Saml2Config()
     spConfig.load(saml_settings)
     spConfig.allow_unknown_attributes = True

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -221,6 +221,9 @@ def acs(r):
     if settings.SAML2_AUTH.get('USE_SIMPLE_JWT') is True:
         refresh = RefreshToken.for_user(target_user)
 
+        refresh['user_username'] = target_user.username
+        refresh['user_email'] = target_user.email
+
         # We use JWT auth send token to frontend
         access_token = str(refresh.access_token)
         refresh_token = str(refresh)

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -23,6 +23,7 @@ from django.http import HttpResponseRedirect
 from django.utils.http import is_safe_url
 
 from rest_auth.utils import jwt_encode
+from rest_framework_simplejwt.tokens import RefreshToken
 
 
 # default User or custom User. Now both will work.
@@ -205,6 +206,19 @@ def acs(r):
         # We use JWT auth send token to frontend
         jwt_token = jwt_encode(target_user)
         query = '?uid={}&token={}'.format(target_user.id, jwt_token)
+
+        frontend_url = settings.SAML2_AUTH.get(
+            'FRONTEND_URL', next_url)
+
+        return HttpResponseRedirect(frontend_url+query)
+
+    if settings.SAML2_AUTH.get('USE_SIMPLE_JWT') is True:
+        refresh = RefreshToken.for_user(target_user)
+
+        # We use JWT auth send token to frontend
+        access_token = str(refresh.access_token)
+        refresh_token = str(refresh)
+        query = '?access={}&refresh={}'.format(access_token, refresh_token)
 
         frontend_url = settings.SAML2_AUTH.get(
             'FRONTEND_URL', next_url)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name='f3f_django_saml2_auth',
 
-    version='2.2.1.1',
+    version='2.2.1.2',
 
     description='Django SAML2 Authentication Made Easy. Easily integrate with SAML2 SSO identity providers like Okta',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='django_saml2_auth',
+    name='f3f_django_saml2_auth',
 
-    version='2.2.1',
+    version='2.2.1.1',
 
     description='Django SAML2 Authentication Made Easy. Easily integrate with SAML2 SSO identity providers like Okta',
     long_description=long_description,
@@ -62,6 +62,7 @@ setup(
 
     install_requires=['pysaml2>=4.5.0',
                       'djangorestframework-jwt',
+                      'djangorestframework-simplejwt',
                       'django-rest-auth', ],
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name='f3f_django_saml2_auth',
 
-    version='2.2.1.2',
+    version='2.2.1.3',
 
     description='Django SAML2 Authentication Made Easy. Easily integrate with SAML2 SSO identity providers like Okta',
     long_description=long_description,


### PR DESCRIPTION
Allowing config for the following parameters:
- Require assertions to be signed
- Require response to be signed

Currently, views.py has True/False for these options hardcoded