### PR TITLE
SAML Group Mappings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,10 @@ How to use?
                 'username': 'UserName',
                 'first_name': 'FirstName',
                 'last_name': 'LastName',
+                'groups': 'Groups', # Optional
+            },
+            'GROUPS_MAP': {  # Optionally allow mapping SAML2 Groups to Django Groups
+                'SAML Group Name': 'Django Group Name',
             },
             'TRIGGER': {
                 'CREATE_USER': 'path.to.your.new.user.hook.method',

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -193,6 +193,30 @@ def acs(r):
         else:
             return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
+    # Optionally update this user's group assignments
+    group_attribute = settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('groups', None)
+    group_map = settings.SAML2_AUTH.get('GROUPS_MAP', None)
+
+    if group_attribute is not None and group_attribute in user_identity:
+        groups = []
+
+        for group_name in user_identity[group_attribute]:
+            # Group names can optionally be mapped to different names in Django
+            if group_map is not None and group_name in group_map:
+                group_name_django = group_map[group_name]
+            else:
+                group_name_django = group_name
+
+            try:
+                groups.append( Group.objects.get(name=group_name_django) )
+            except Group.DoesNotExist:
+                pass
+
+        if parse_version(get_version()) >= parse_version('2.0'):
+            target_user.groups.set(groups)
+        else:
+            target_user.groups = groups
+
     r.session.flush()
 
     if target_user.is_active:


### PR DESCRIPTION
This pull request makes it possible to map Groups from a SAML2 provider to Django Auth Groups. If groups are enabled, they replace all existing groups on a Django user account each time the user logs in.

I have tested this on Okta.