### PR TITLE
Okta-Specific README Clarification

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,4 +29,5 @@ Contributors
 - `BaconAndEggs <https://github.com/BaconAndEggs>`_
 - `Ryan Mahaffey <https://github.com/mahaffey>`_
 - `ayr-ton <https://github.com/ayr-ton>`_
-_ `kevPo <https://github.com/kevPo>`_
+- `kevPo <https://github.com/kevPo>`_
+- `Griffin J Rademacher <https://github.com/favorable-mutation>`_

--- a/README.rst
+++ b/README.rst
@@ -262,7 +262,7 @@ The ``Identity Provider metadata`` link is the ``METADATA_AUTO_CONF_URL``.
 
 More information can be found in the `Okta Developer Documentation`_.
 
-..  `Okta developer documentation`: https://developer.okta.com/docs/guides/saml-application-setup/overview/
+..  _`Okta developer documentation`: https://developer.okta.com/docs/guides/saml-application-setup/overview/
 
 
 How to Contribute

--- a/README.rst
+++ b/README.rst
@@ -260,9 +260,9 @@ you should see::
 
 The ``Identity Provider metadata`` link is the ``METADATA_AUTO_CONF_URL``.
 
-More information can be found in the `Okta Developer Documentation`.
+More information can be found in the `Okta Developer Documentation`_.
 
-.. `Okta developer documentation`: https://developer.okta.com/docs/guides/saml-application-setup/overview/
+..  `Okta developer documentation`: https://developer.okta.com/docs/guides/saml-application-setup/overview/
 
 
 How to Contribute

--- a/README.rst
+++ b/README.rst
@@ -252,13 +252,18 @@ For Okta Users
 
 I created this plugin originally for Okta.
 
-The METADATA_AUTO_CONF_URL needed in ``settings.py`` can be found in the Okta
-web UI by navigating to the SAML2 app's ``Sign On`` tab, in the Settings box.
-You should see :
+The ``METADATA_AUTO_CONF_URL`` needed in ``settings.py`` can be found in the Okta
+web UI by navigating to the SAML2 app's ``Sign On`` tab. In the ``Settings`` box,
+you should see:
 
-`Identity Provider metadata is available if this application supports dynamic configuration.`
+    .. code-block: markdown
+    Identity Provider metadata is available if this application supports dynamic configuration.
 
 The ``Identity Provider metadata`` link is the METADATA_AUTO_CONF_URL.
+
+More information can be found in the `Okta developer documentation`.
+
+.. `Okta developer documentation`: https://developer.okta.com/docs/guides/saml-application-setup/overview/
 
 
 How to Contribute

--- a/README.rst
+++ b/README.rst
@@ -254,9 +254,8 @@ I created this plugin originally for Okta.
 
 The ``METADATA_AUTO_CONF_URL`` needed in ``settings.py`` can be found in the Okta
 Web UI by navigating to the SAML2 app's ``Sign On`` tab. In the ``Settings`` box,
-you should see:
+you should see::
 
-    .. code-block: markdown
     Identity Provider metadata is available if this application supports dynamic configuration.
 
 The ``Identity Provider metadata`` link is the ``METADATA_AUTO_CONF_URL``.

--- a/README.rst
+++ b/README.rst
@@ -253,15 +253,15 @@ For Okta Users
 I created this plugin originally for Okta.
 
 The ``METADATA_AUTO_CONF_URL`` needed in ``settings.py`` can be found in the Okta
-web UI by navigating to the SAML2 app's ``Sign On`` tab. In the ``Settings`` box,
+Web UI by navigating to the SAML2 app's ``Sign On`` tab. In the ``Settings`` box,
 you should see:
 
     .. code-block: markdown
     Identity Provider metadata is available if this application supports dynamic configuration.
 
-The ``Identity Provider metadata`` link is the METADATA_AUTO_CONF_URL.
+The ``Identity Provider metadata`` link is the ``METADATA_AUTO_CONF_URL``.
 
-More information can be found in the `Okta developer documentation`.
+More information can be found in the `Okta Developer Documentation`.
 
 .. `Okta developer documentation`: https://developer.okta.com/docs/guides/saml-application-setup/overview/
 

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ We accept your donations by clicking the awesome |star| instead of any physical 
 Dependencies
 ============
 
-This plugin is compatible with Django 1.6/1.7/1.8/1.9/1.10. The `pysaml2` Python
+This plugin is compatible with Django 1.6/1.7/1.8/1.9/1.10. The ``pysaml2`` Python
 module is required.
 
 
@@ -53,7 +53,7 @@ module is required.
 Install
 =======
 
-You can install this plugin via `pip`:
+You can install this plugin via ``pip``:
 
 .. code-block:: bash
 
@@ -99,7 +99,7 @@ How to use?
         import django_saml2_auth.views
 
 #. Override the default login page in the root urls.py file, by adding these
-   lines **BEFORE** any `urlpatterns`:
+   lines **BEFORE** any ``urlpatterns``:
 
     .. code-block:: python
 
@@ -216,7 +216,7 @@ With these params your client can now authenticate will server resources.
 Customize
 =========
 
-The default permission `denied` page and user `welcome` page can be
+The default permission ``denied`` page and user ``welcome`` page can be
 overridden.
 
 To override these pages put a template named 'django_saml2_auth/welcome.html'
@@ -226,10 +226,10 @@ If a 'django_saml2_auth/welcome.html' template exists, that page will be shown
 to the user upon login instead of the user being redirected to the previous
 visited page. This welcome page can contain some first-visit notes and welcome
 words. The `Django user object <https://docs.djangoproject.com/en/1.9/ref/contrib/auth/#django.contrib.auth.models.User>`_
-is available within the template as the `user` template variable.
+is available within the template as the ``user`` template variable.
 
 To enable a logout page, add the following lines to urls.py, before any
-`urlpatterns`:
+``urlpatterns``:
 
 .. code-block:: python
 
@@ -243,8 +243,8 @@ To override the built in signout page put a template named
 'django_saml2_auth/signout.html' in your project's template folder.
 
 If your SAML2 identity provider uses user attribute names other than the
-defaults listed in the `settings.py` `ATTRIBUTES_MAP`, update them in
-`settings.py`.
+defaults listed in the ``settings.py`` ``ATTRIBUTES_MAP``, update them in
+``settings.py``.
 
 
 For Okta Users
@@ -252,13 +252,13 @@ For Okta Users
 
 I created this plugin originally for Okta.
 
-The METADATA_AUTO_CONF_URL needed in `settings.py` can be found in the Okta
-web UI by navigating to the SAML2 app's `Sign On` tab, in the Settings box.
+The METADATA_AUTO_CONF_URL needed in ``settings.py`` can be found in the Okta
+web UI by navigating to the SAML2 app's ``Sign On`` tab, in the Settings box.
 You should see :
 
 `Identity Provider metadata is available if this application supports dynamic configuration.`
 
-The `Identity Provider metadata` link is the METADATA_AUTO_CONF_URL.
+The ``Identity Provider metadata`` link is the METADATA_AUTO_CONF_URL.
 
 
 How to Contribute


### PR DESCRIPTION
The section of the `README` dealing with setup for Okta can be a bit difficult to understand if you don't know exactly what you're looking for; this PR clarifies those instructions somewhat and links to a page with an image replicating what you should be looking for in the Okta Web UI.

There are also some elements of the `README` that should probably be `code`-formatted. This PR adds double backticks around such elements that only had single backticks, allowing GitHub to parse them as inline `code`-formatted.