### PR TITLE
Allow redirect hosts whitelist

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,7 @@ How to use?
             'NAME_ID_FORMAT': FormatString, # Sets the Format property of authn NameIDPolicy element
             'USE_JWT': False, # Set this to True if you are running a Single Page Application (SPA) with Django Rest Framework (DRF), and are using JWT authentication to authorize client users
             'FRONTEND_URL': 'https://myfrontendclient.com', # Redirect URL for the client if you are using JWT auth with DRF. See explanation below
+            'ALLOWED_REDIRECT_HOSTS': ["https://myfrontendclient.com"] # Allowed hosts to redirect to using the ?next parameter
         }
 
 #. In your SAML2 SSO identity provider, set the Single-sign-on URL and Audience

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -185,7 +185,7 @@ def acs(r):
             import_string(settings.SAML2_AUTH['TRIGGER']['BEFORE_LOGIN'])(user_identity)
     except User.DoesNotExist:
         new_user_should_be_created = settings.SAML2_AUTH.get('CREATE_USER', True)
-        if new_user_should_be_created: 
+        if new_user_should_be_created:
             target_user = _create_new_user(user_name, user_email, user_first_name, user_last_name)
             if settings.SAML2_AUTH.get('TRIGGER', {}).get('CREATE_USER', None):
                 import_string(settings.SAML2_AUTH['TRIGGER']['CREATE_USER'])(user_identity)
@@ -236,8 +236,9 @@ def signin(r):
         next_url = r.GET.get('next', _default_next_url())
 
     # Only permit signin requests where the next_url is a safe URL
+    allowed_hosts = set(settings.SAML2_AUTH.get('ALLOWED_REDIRECT_HOSTS') or [])
     if parse_version(get_version()) >= parse_version('2.0'):
-        url_ok = is_safe_url(next_url, None)
+        url_ok = is_safe_url(next_url, allowed_hosts)
     else:
         url_ok = is_safe_url(next_url)
 


### PR DESCRIPTION
Created a setting to specify which domains are allowed for SAML2 redirects with POST binding.

Our use case was local development with a React client.