### PR TITLE
Directions for implementing saml2 with custom user model.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -246,6 +246,8 @@ If your SAML2 identity provider uses user attribute names other than the
 defaults listed in the `settings.py` `ATTRIBUTES_MAP`, update them in
 `settings.py`.
 
+If using a custom User model, update or remove the Backend model specification in views.py
+
 
 For Okta Users
 ==============

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -196,6 +196,7 @@ def acs(r):
     r.session.flush()
 
     if target_user.is_active:
+        # When using a custom User model, update or remove this backend model specification
         target_user.backend = 'django.contrib.auth.backends.ModelBackend'
         login(r, target_user)
     else:


### PR DESCRIPTION
I had trouble figuring out why after properly logging in through SSO and login being called on the appropriate user, why I wasn't logged in. It turns it it was because I'm using a custom User model and the user backend override is preventing login (even if the user is created through this module). I am not sure of the purpose of forcing the backend, so I thought the best thing to do was update the README and make a note in the code.