### PR TITLE
Update to use get_by_natural_key

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -180,7 +180,7 @@ def acs(r):
     is_new_user = False
 
     try:
-        target_user = User.objects.get(username=user_name)
+        target_user = User.objects.get_by_natural_key(user_name)
         if settings.SAML2_AUTH.get('TRIGGER', {}).get('BEFORE_LOGIN', None):
             import_string(settings.SAML2_AUTH['TRIGGER']['BEFORE_LOGIN'])(user_identity)
     except User.DoesNotExist:


### PR DESCRIPTION
Django's custom user models can use an alternate field for the username - the usage of get means that we are tied to the username field - instead, change to using get_by_natural_key, which retrieves the user instance by using the field specified in USERNAME_FIELD attribute of the User model.