### PR TITLE
Ability to access SAML Response to integrate with OAuth2 Clients

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -158,6 +158,9 @@ def acs(r):
     saml_client = _get_saml_client(get_current_domain(r))
     resp = r.POST.get('SAMLResponse', None)
     next_url = r.session.get('login_next_url', _default_next_url())
+    
+    # Add SAMLResponse as SAML Assertion for OAuth2 Token
+    r.session['saml_assertion'] = resp
 
     if not resp:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
@@ -193,7 +196,7 @@ def acs(r):
         else:
             return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
-    r.session.flush()
+    # r.session.flush()
 
     if target_user.is_active:
         target_user.backend = 'django.contrib.auth.backends.ModelBackend'


### PR DESCRIPTION
Azure AD supports SAML Assertion OAuth Token approach, where user's SAML Token can be used to get the OAuth2 token. This token then used to query user specific O365 objects using Graph API.

If there are other alternatives to get the SAML Response during user's session, please suggest.