### PR TITLE
Pass the User instance to hook methods

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -182,13 +182,13 @@ def acs(r):
     try:
         target_user = User.objects.get(username=user_name)
         if settings.SAML2_AUTH.get('TRIGGER', {}).get('BEFORE_LOGIN', None):
-            import_string(settings.SAML2_AUTH['TRIGGER']['BEFORE_LOGIN'])(user_identity)
+            import_string(settings.SAML2_AUTH['TRIGGER']['BEFORE_LOGIN'])(user_identity, target_user)
     except User.DoesNotExist:
         new_user_should_be_created = settings.SAML2_AUTH.get('CREATE_USER', True)
         if new_user_should_be_created: 
             target_user = _create_new_user(user_name, user_email, user_first_name, user_last_name)
             if settings.SAML2_AUTH.get('TRIGGER', {}).get('CREATE_USER', None):
-                import_string(settings.SAML2_AUTH['TRIGGER']['CREATE_USER'])(user_identity)
+                import_string(settings.SAML2_AUTH['TRIGGER']['CREATE_USER'])(user_identity, target_user)
             is_new_user = True
         else:
             return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))


### PR DESCRIPTION
This is related to issue #163 

With this new signature, we can implement hooks to check user may log in using SAML for instance:

```python
def before_login_hook(user_identity, target_user):
    """Check user SAML flag"""
    if not target_user.saml_login_enabled:
        raise PermissionDenied("User cannot login")
 
 def create_user_hook(user_identity, target_user):
     """Automatically allow login for user created through SAML"""
     target_user.saml_login_enabled = True
     target_user.save()
```

Note: this should be mentioned in changelog, as it requires updating the signature of the hooks methods.