### PR TITLE
ADD: Possibility to change admin:index reverse entrypoint

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -45,7 +45,7 @@ def _default_next_url():
     if 'DEFAULT_NEXT_URL' in settings.SAML2_AUTH:
         return settings.SAML2_AUTH['DEFAULT_NEXT_URL']
     # Lazily evaluate this in case we don't have admin loaded.
-    return get_reverse('admin:index')
+    return get_reverse('admin:index' if 'REVERSE_URL' not in settings.SAML2_AUTH.keys() else settings.SAML2_AUTH['REVERSE_URL'])
 
 
 def get_current_domain(r):


### PR DESCRIPTION
Added possibility to change reverse ADMIN:INDEX entrypoint.
For django application without admin page, add `REVERSE_URL` to overwrite `admin:index` in the SAML2_AUTH.

Should make it a lot easier to fix
```
Exception: We got a URL reverse issue: ['admin:index']. This is a known issue but please still submit a ticket at https://github.com/fangli/django-saml2-auth/issues/new
```

<img width="178" alt="image" src="https://user-images.githubusercontent.com/14298262/206146990-1ed1562b-55f3-4b10-ba46-6fdad2098b3c.png">

Note that DEFAULT_NEXT_URL won't skip the `admin:index` if changed. You still require an admin page for some reason.
