### PR TITLE
python 2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# VSCode
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -260,6 +260,11 @@ You should see :
 
 The `Identity Provider metadata` link is the METADATA_AUTO_CONF_URL.
 
+Additional Notes
+================
+
+- in the acs method, the local user is determined from the SAML assertion returned by the identity provider, based on a `username` match 
+
 
 How to Contribute
 =================

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -167,9 +167,6 @@ def acs(r):
         logging.error('login request from identity provider does not contain a saml response ')
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
     
-    # DEBUG
-    logging.info('raw SAML rsp received from identity provider: {}'.format(resp))
-
     authn_response = saml_client.parse_authn_request_response(resp, entity.BINDING_HTTP_POST)
     if authn_response is None:
         authn_response = saml_client.parse_authn_request_response(resp, entity.BINDING_HTTP_ARTIFACT)

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -169,7 +169,8 @@ def acs(r):
 
     authn_response = saml_client.parse_authn_request_response(resp, entity.BINDING_HTTP_POST)
     if authn_response is None:
-        logging.error('login request from identity provider contains a SAML response that could not be parsed')
+        logging.error(
+            'login request from identity provider contains a SAML response that could not be parsed: {}'.format(resp))
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
     user_identity = authn_response.get_identity()

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -172,6 +172,9 @@ def acs(r):
 
     authn_response = saml_client.parse_authn_request_response(resp, entity.BINDING_HTTP_POST)
     if authn_response is None:
+        authn_response = saml_client.parse_authn_request_response(resp, entity.BINDING_HTTP_ARTIFACT)
+    
+    if authn_response is None:
         logging.error(
             'login request from identity provider contains a SAML response that could not be parsed: {}'.format(resp))
 

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -166,11 +166,15 @@ def acs(r):
     if not resp:
         logging.error('login request from identity provider does not contain a saml response ')
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
+    
+    # DEBUG
+    logging.info('raw SAML rsp received from identity provider: {}'.format(resp))
 
     authn_response = saml_client.parse_authn_request_response(resp, entity.BINDING_HTTP_POST)
     if authn_response is None:
         logging.error(
             'login request from identity provider contains a SAML response that could not be parsed: {}'.format(resp))
+
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
     user_identity = authn_response.get_identity()

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name='django_saml2_auth',
 
-    version='2.2.1',
+    version='2.2.2',
 
     description='Django SAML2 Authentication Made Easy. Easily integrate with SAML2 SSO identity providers like Okta',
     long_description=long_description,
@@ -49,18 +49,13 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
     ],
 
     keywords='Django SAML2 Authentication Made Easy, integrate with SAML2 SSO such as Okta easily',
 
     packages=find_packages(),
 
-    install_requires=['pysaml2>=4.5.0',
+    install_requires=['pysaml2==4.5.0',
                       'djangorestframework-jwt',
                       'django-rest-auth', ],
     include_package_data=True,


### PR DESCRIPTION
- doc note on criterion for matching saml user identity to django user (namely, on username)
- only import jwt_encode from rest_auth.utils if USE_JWT setting is True
- user authentication backend now configurable via AUTHENTICATION_BACKEND setting, defaulting to django.contrib.auth.backends.ModelBackend'
- added login callback method configurable  via TRIGGER.LOGIN setting
- some info logging